### PR TITLE
Fix Gradle settings: use dependencyResolutionManagement for Gradle 8.11.1

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -11,8 +11,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-dependencyResolution {
-    @Suppress("UnstableApiUsage")
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- Replace `dependencyResolution` with `dependencyResolutionManagement` in `android/settings.gradle.kts`
- The `dependencyResolution` API was introduced in Gradle 8.14, but the project uses Gradle 8.11.1, causing build failures with "Unresolved reference" errors
- Added `repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)` as the standard configuration for centralized dependency management

## Test plan
- [ ] Run Gradle sync in Android Studio / IntelliJ to verify the settings file compiles without errors
- [ ] Run `./gradlew build` to confirm the project builds successfully

https://claude.ai/code/session_01SZs5emuH6RbjWqbNxGFdCp