### PR TITLE
Fix watchdog.ps1 parse error that prevented the service from starting

### DIFF
--- a/src/watchdog.ps1
+++ b/src/watchdog.ps1
@@ -954,7 +954,7 @@ function Ensure-Role {
         # Pass the config so MySQL recycles via the same graceful shutdown used by
         # normal stop commands (flush/checkpoint before exit), only force-killing if
         # the database is unreachable. Without it InnoDB could be terminated mid-write.
-        try { Stop-Role -Role $Role -Cfg $Cfg } catch { Log "ERROR stopping stale $Role: $($_)" }
+        try { Stop-Role -Role $Role -Cfg $Cfg } catch { Log "ERROR stopping stale ${Role}: $($_)" }
         if ($script:PortWarmupStart) { $script:PortWarmupStart.Remove($Role) | Out-Null }
         if (-not (Wait-ForRoleDown -Role $Role -ExpectedPath $Path -TimeoutSec 15)) {
             Log "WARNING: stale $Role still running after stop request; deferring relaunch to avoid duplicate instances."


### PR DESCRIPTION
## Problem

After PR #28, starting the watchdog service fails:

```
ERROR: Failed to start service: Failed to start service 'WoW Watchdog (WoWWatchdog)'.
```

## Root cause

A **parse error** in `src/watchdog.ps1`, introduced in PR #28. The wedged-process recovery path in `Ensure-Role` logs:

```powershell
Log "ERROR stopping stale $Role: $($_)"
```

PowerShell parses `$Role:` inside a double-quoted string as a **scoped/drive-qualified variable reference** (the same syntax as `$env:PATH` or `$script:foo`). Because the colon is immediately followed by a space rather than a variable name, it is a hard syntax error:

```
Line 957, Col 83: Variable reference is not valid. ':' was not followed by a
valid variable name character. Consider using ${} to delimit the name.
```

A single parse error makes the **entire script** fail to load. The service is `powershell.exe -File watchdog.ps1` wrapped by NSSM, so the process exits immediately on launch and the Service Control Manager reports "Failed to start service". This is why the regression only surfaced at runtime — it was never caught in review (Codex reviews the diff; it doesn't run the parser), and a PowerShell parser wasn't available in the session that produced #28.

## Fix

Delimit the variable name so the colon is treated as a literal:

```powershell
Log "ERROR stopping stale ${Role}: $($_)"
```

## Verification

Ran the PowerShell language parser (`[System.Management.Automation.Language.Parser]::ParseFile`) against both scripts:

- Before: `watchdog.ps1` → 1 parse error at line 957; `WoWWatcherGUI.ps1` → clean.
- After: **both scripts parse with zero errors.**

Also grep-scanned both files for any other `$var:` patterns that could parse-as-scope (excluding the legitimate `$env:`/`$script:`/etc. and the GUI's backtick-escaped `` `: ``) — this was the only occurrence.

## Note
This is a one-character-class fix (`$Role` → `${Role}`); no behavior changes beyond making the script load. Recommend merging promptly since the service cannot start without it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpY8x5aJEvZRVK1UsPciGn)_